### PR TITLE
Return a single object for single-col enumerator

### DIFF
--- a/src/main/java/net/hydromatic/optiq/impl/csv/CsvTable.java
+++ b/src/main/java/net/hydromatic/optiq/impl/csv/CsvTable.java
@@ -85,9 +85,9 @@ public class CsvTable extends AbstractQueryableTable
   }
 
   /** Returns an enumerable over a given projection of the fields. */
-  public Enumerable<Object[]> project(final int[] fields) {
-    return new AbstractEnumerable<Object[]>() {
-      public Enumerator<Object[]> enumerator() {
+  public Enumerable<Object> project(final int[] fields) {
+    return new AbstractEnumerable<Object>() {
+      public Enumerator<Object> enumerator() {
         return new CsvEnumerator(file,
             fieldTypes.toArray(new CsvFieldType[fieldTypes.size()]), fields);
       }

--- a/src/test/java/net/hydromatic/optiq/test/CsvTest.java
+++ b/src/test/java/net/hydromatic/optiq/test/CsvTest.java
@@ -107,6 +107,10 @@ public class CsvTest {
     checkSql("model", "select * from EMPS");
   }
 
+  @Test public void testSelectSingleProject() throws SQLException {
+    checkSql("smart", "select name from EMPS");
+  }
+
   @Test public void testCustomTable() throws SQLException {
     checkSql("model-with-custom-table", "select * from CUSTOM_TABLE.EMPS");
   }


### PR DESCRIPTION
Optiq expects that an enumerator of a single column returns the single value of that column, and not an array with length 1. This causes a problem when a single column is selected using the "smart" version of the optiq-csv driver, as it always returns an array of values, even if only one has been requested.

This PR changes the CsvEnumerator to be generically typed as Object instead of Object[], and return a single object when only a single column is being read (instead of an array).

The issue is demonstrated in CsvTest#testSelectSingleProject.
